### PR TITLE
enable layout field in appearance tab

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -32,4 +32,4 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$pluginSignat
 /**
  * Remove unused fields
  */
-$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist'][$pluginSignature] = 'layout,select_key';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist'][$pluginSignature] = 'select_key';


### PR DESCRIPTION
The "Layout" drop down box is disabled and thus can't be used for the custom templates as proposed in https://github.com/machwatt/sf_filecollection_gallery/pull/55

This change reenables the layout field.